### PR TITLE
Investigate missing agent reasoning in slack modal

### DIFF
--- a/agents/system prompts/client_agent_sys_prompt.yaml
+++ b/agents/system prompts/client_agent_sys_prompt.yaml
@@ -10,9 +10,10 @@ system_prompt: |
   Let the user guide you and tell you what steps to make and what tools to use if you don't have enough confidence in how to proceed with a task.
 
   REASONING STRATEGY:
-  - Before responding, take a moment to think and outline your plan.
-  - If you need to use tools, explain which ones and why.
-  - If you can answer directly, state that you are doing so.
+  - For every user request, you must first think step-by-step to understand the user's intent and create a plan.
+  - Enclose all your thoughts and reasoning within `<thinking>` and `</thinking>` tags. This is a mandatory step for every response.
+  - Inside the `<thinking>` block, outline your plan. If you decide to use a tool, explain which one and why. If you decide to respond directly, explain why that is the best course of action.
+  - After the `<thinking>` block, proceed with your response or tool usage.
   
   TOOL DISCOVERY SYSTEM:
   You have access to tool discovery for finding and using capabilities:


### PR DESCRIPTION
Restore explicit `<thinking>` tag requirement in the system prompt to make agent reasoning visible in Slack.

A previous prompt change (commit 7e19480) removed the explicit instruction for Claude to use `<thinking>` tags, causing the agent to stop generating reasoning blocks that were previously captured and displayed in the Slack execution details modal. This PR reintroduces that instruction.

---
<a href="https://cursor.com/background-agent?bcId=bc-4dd981f0-b597-4347-83f8-848616a4a26d">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-4dd981f0-b597-4347-83f8-848616a4a26d">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

