### PR TITLE
Handle invalid request budget token error

### DIFF
--- a/agents/client_agent.py
+++ b/agents/client_agent.py
@@ -47,6 +47,9 @@ class ClientAgent:
         self.max_tokens = self.config.get('model_config', {}).get('max_tokens', 4096)
         self.temperature = self.config.get('model_config', {}).get('temperature', 0.7)
         self.max_iterations = self.config.get('model_config', {}).get('max_iterations', 50)
+        self.thinking_budget_tokens = self.config.get('model_config', {}).get('thinking_budget_tokens', 2048)
+        if self.thinking_budget_tokens < 1024:
+            self.thinking_budget_tokens = 1024
         
         # Define function schemas for Claude - use underscore format per Anthropic API constraints
         self.tools = [
@@ -311,7 +314,7 @@ class ClientAgent:
                     system=self.system_prompt,
                     messages=messages,
                     tools=self.tools,
-                    thinking={"type": "enabled", "budget_tokens": 512},
+                    thinking={"type": "enabled", "budget_tokens": self.thinking_budget_tokens},
                     timeout=60.0  # Add timeout to prevent streaming errors
                 )
             )

--- a/agents/system prompts/client_agent_sys_prompt.yaml
+++ b/agents/system prompts/client_agent_sys_prompt.yaml
@@ -66,6 +66,7 @@ model_config:
   max_tokens: 4096
   temperature: 0.4
   max_iterations: 24
+  thinking_budget_tokens: 2048
 
 # Metadata
 version: "1.0"


### PR DESCRIPTION
Make `thinking.budget_tokens` configurable and enforce minimum 1024 to resolve API error.

---
<a href="https://cursor.com/background-agent?bcId=bc-516d3383-2671-42d4-8009-7ce80adf179c">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-516d3383-2671-42d4-8009-7ce80adf179c">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

