### PR TITLE
Investigate deployment time increase

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,13 +48,8 @@ GEMINI_API_KEY=your_gemini_key_here
 ### 2. Install Dependencies
 
 ```bash
-# Install dependencies
-pip install numpy==1.24.* sentence-transformers==5.0.0 transformers>=4.51.0
-pip install FlagEmbedding>=1.2.9 faiss-cpu>=1.7.0 httpx openai
-pip install flask>=2.0.0 python-dotenv>=0.19.0 typing-extensions>=4.0.0
-
-# Install other dependencies
-pip install anthropic pydantic python-dotenv pyyaml httpx asyncio
+# Install dependencies using requirements.txt
+pip install -r requirements.txt
 ```
 
 ### 3. Set Python Path

--- a/nixpacks.toml
+++ b/nixpacks.toml
@@ -5,13 +5,5 @@
 NIXPACKS_PYTHON_VERSION = "3.11"
 
 [phases.setup]
-# Add a comprehensive set of system packages required for building complex 
-# Python dependencies with C++ and Fortran backends, like faiss-cpu.
-pkgs = [
-    "gcc", 
-    "gfortran",
-    "cmake",
-    "pkg-config",
-    "liblapack",
-    "libomp"
-]
+# Basic system packages for Python dependencies
+pkgs = ["gcc"]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,8 +1,6 @@
 # CORE DEPENDENCIES
 setuptools>=65.0.0
 wheel
-faiss-cpu>=1.8.0
-sentence-transformers==2.7.0
 
 # MAIN APPLICATION DEPENDENCIES
 aiohttp>=3.12.15
@@ -20,8 +18,3 @@ slack-bolt>=1.23.0
 uvicorn[standard]>=0.35.0
 # Note: MemoryOS functionality is optional - the package is not publicly available
 # The application will work without it, with memory features disabled
-
-# Additional dependencies from pyproject.toml
-numpy>=1.24.0
-torch>=2.0.0
-transformers>=4.30.0


### PR DESCRIPTION
Remove unused heavy ML dependencies and associated build configurations to reduce deployment time.

These dependencies (e.g., `torch`, `transformers`, `faiss-cpu`) were previously required for MemoryOS integration, which has since been deployed as a separate service. Removing them restores the original ~5-minute deployment time.

---
<a href="https://cursor.com/background-agent?bcId=bc-f7db7236-94e2-4363-9d2e-a47bc81e8632">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-f7db7236-94e2-4363-9d2e-a47bc81e8632">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

