### PR TITLE
Handle temperature parameter error for extended thinking

### DIFF
--- a/agents/client_agent.py
+++ b/agents/client_agent.py
@@ -47,9 +47,7 @@ class ClientAgent:
         self.max_tokens = self.config.get('model_config', {}).get('max_tokens', 4096)
         self.temperature = self.config.get('model_config', {}).get('temperature', 0.7)
         self.max_iterations = self.config.get('model_config', {}).get('max_iterations', 50)
-        self.thinking_budget_tokens = self.config.get('model_config', {}).get('thinking_budget_tokens', 2048)
-        if self.thinking_budget_tokens < 1024:
-            self.thinking_budget_tokens = 1024
+
         
         # Define function schemas for Claude - use underscore format per Anthropic API constraints
         self.tools = [
@@ -314,7 +312,6 @@ class ClientAgent:
                     system=self.system_prompt,
                     messages=messages,
                     tools=self.tools,
-                    thinking={"type": "enabled", "budget_tokens": self.thinking_budget_tokens},
                     timeout=60.0  # Add timeout to prevent streaming errors
                 )
             )

--- a/agents/system prompts/client_agent_sys_prompt.yaml
+++ b/agents/system prompts/client_agent_sys_prompt.yaml
@@ -64,9 +64,8 @@ system_prompt: |
 # Additional configuration for the client agent
 model_config:
   max_tokens: 4096
-  temperature: 1.0
+  temperature: 0.4
   max_iterations: 24
-  thinking_budget_tokens: 2048
 
 # Metadata
 version: "1.0"

--- a/agents/system prompts/client_agent_sys_prompt.yaml
+++ b/agents/system prompts/client_agent_sys_prompt.yaml
@@ -64,7 +64,7 @@ system_prompt: |
 # Additional configuration for the client agent
 model_config:
   max_tokens: 4096
-  temperature: 0.4
+  temperature: 1.0
   max_iterations: 24
   thinking_budget_tokens: 2048
 


### PR DESCRIPTION
Disable extended thinking and remove related configurations to use regular reasoning and avoid `temperature=1` constraint.

---
<a href="https://cursor.com/background-agent?bcId=bc-7449be59-4d9d-4cb3-8ee5-d47e017e1328">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-7449be59-4d9d-4cb3-8ee5-d47e017e1328">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

