### PR TITLE
Debug slack coroutine attribute error

### DIFF
--- a/agents/client_agent.py
+++ b/agents/client_agent.py
@@ -1265,7 +1265,6 @@ Note: scratchpad.add_finding requires 'summary' parameter, not 'finding'."""
                 }
                 if streaming_callback:
                     await streaming_callback({"name": "scratchpad.add_finding", "args": add_args}, "tool_start")
-                    await streaming_callback("scratchpad.add_finding", "tool_start")
                 _ = await self.tool_executor.execute_command("scratchpad.add_finding", add_args, user_id=user_id)
                 findings_made = 1
 


### PR DESCRIPTION
Fixes `AttributeError: 'coroutine' object has no attribute 'strip'` in Slack streaming callback by robustly handling coroutine objects and ensuring content is a string before string operations.

The `slack_streaming_callback` was occasionally receiving coroutine objects instead of strings for its `content` parameter, particularly for "thinking" content. This led to an `AttributeError` when `.strip()` was invoked on the coroutine. The changes introduce comprehensive checks to detect and `await` coroutines or async functions, convert content to a string if necessary, and add general error handling to prevent similar issues and improve debuggability. A redundant `streaming_callback` call in `client_agent.py` was also removed.

---
<a href="https://cursor.com/background-agent?bcId=bc-aae3609f-02b5-42e7-8a94-e9292c9c07c2">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-aae3609f-02b5-42e7-8a94-e9292c9c07c2">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

